### PR TITLE
Restructured exception and api imports

### DIFF
--- a/lasif/__init__.py
+++ b/lasif/__init__.py
@@ -1,37 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from lasif import api
+from lasif.exceptions import (
+    LASIFAdjointSourceCalculationError,
+    LASIFCommandLineException,
+    LASIFError,
+    LASIFNotFoundError,
+    LASIFWarning,
+)
 from .version import get_git_version
 
+__all__ = [
+    "api",
+    "LASIFAdjointSourceCalculationError",
+    "LASIFError",
+    "LASIFNotFoundError",
+    "LASIFWarning",
+    "LASIFCommandLineException",
+]
+
 __version__ = get_git_version()
-
-
-class LASIFError(Exception):
-    """
-    Base exception class for LASIF.
-    """
-
-    pass
-
-
-class LASIFNotFoundError(LASIFError):
-    """
-    Raised whenever something is not found inside the project.
-    """
-
-    pass
-
-
-class LASIFAdjointSourceCalculationError(LASIFError):
-    """
-    Raised when something goes wrong when calculating an adjoint source.
-    """
-
-    pass
-
-
-class LASIFWarning(UserWarning):
-    """
-    Base warning class for LASIF.
-    """
-
-    pass

--- a/lasif/adjoint_sources/ad_src_cc_dd.py
+++ b/lasif/adjoint_sources/ad_src_cc_dd.py
@@ -15,7 +15,7 @@ from scipy.integrate import simps
 from obspy.signal.invsim import cosine_taper
 import obspy.signal.cross_correlation as crosscorr
 from obspy.geodetics.base import gps2dist_azimuth, kilometer2degrees
-from lasif import LASIFError
+from lasif.exceptions import LASIFError
 from obspy.core import Trace
 
 

--- a/lasif/adjoint_sources/ad_src_cc_time_shift.py
+++ b/lasif/adjoint_sources/ad_src_cc_time_shift.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy.integrate import simps
 from obspy.signal.invsim import cosine_taper
 import obspy.signal.cross_correlation as crosscorr
-from lasif import LASIFError
+from lasif.exceptions import LASIFError
 
 
 def cc_time_shift(data, synthetic, dt, shift):

--- a/lasif/adjoint_sources/ad_src_l2_norm_weighted.py
+++ b/lasif/adjoint_sources/ad_src_l2_norm_weighted.py
@@ -12,7 +12,7 @@ Simple L2-norm misfit.
 import numpy as np
 from obspy.signal.invsim import cosine_taper
 from scipy.integrate import simps
-from lasif import LASIFNotFoundError
+from lasif.exceptions import LASIFNotFoundError
 
 
 def find_envelope(station, asdf_file):

--- a/lasif/adjoint_sources/ad_src_tf_phase_misfit.py
+++ b/lasif/adjoint_sources/ad_src_tf_phase_misfit.py
@@ -18,7 +18,7 @@ import obspy
 from obspy.signal.interpolation import lanczos_interpolation
 
 
-from lasif import LASIFAdjointSourceCalculationError
+from lasif.exceptions import LASIFAdjointSourceCalculationError
 from lasif.adjoint_sources import time_frequency, utils
 
 eps = np.spacing(1)

--- a/lasif/api.py
+++ b/lasif/api.py
@@ -19,14 +19,14 @@ import toml
 import numpy as np
 from typing import Union, List
 
-from lasif import LASIFError
 from lasif.components.communicator import Communicator
 from lasif.components.project import Project
-from lasif import LASIFNotFoundError
 
-
-class LASIFCommandLineException(Exception):
-    pass
+from lasif.exceptions import (
+    LASIFError,
+    LASIFAdjointSourceCalculationError,
+    LASIFCommandLineException,
+)
 
 
 def find_project_comm(folder):

--- a/lasif/components/adjoint_sources.py
+++ b/lasif/components/adjoint_sources.py
@@ -8,7 +8,7 @@ import numpy as np
 from lasif.utils import process_two_files_without_parallel_output
 
 from lasif.exceptions import LASIFNotFoundError
-from lasif.component import Component
+from .component import Component
 from lasif.tools.adjoint.adjoint_source import calculate_adjoint_source
 
 # Map the adjoint source type names to functions implementing them.
@@ -403,7 +403,9 @@ class AdjointSourcesComponent(Component):
                     # Start time in nanoseconds
                     source.attrs[
                         "start_time_in_seconds"
-                    ] = self.comm.project.simulation_settings["start_time_in_s"]
+                    ] = self.comm.project.simulation_settings[
+                        "start_time_in_s"
+                    ]
 
                     # toml_string += f"[[source]]\n" \
                     #               f"name = \"{station}\"\n" \

--- a/lasif/components/adjoint_sources.py
+++ b/lasif/components/adjoint_sources.py
@@ -7,8 +7,8 @@ import os
 import numpy as np
 from lasif.utils import process_two_files_without_parallel_output
 
-from lasif import LASIFNotFoundError
-from .component import Component
+from lasif.exceptions import LASIFNotFoundError
+from lasif.component import Component
 from lasif.tools.adjoint.adjoint_source import calculate_adjoint_source
 
 # Map the adjoint source type names to functions implementing them.

--- a/lasif/components/events.py
+++ b/lasif/components/events.py
@@ -11,7 +11,7 @@ import glob
 import obspy
 
 from .component import Component
-from lasif import LASIFNotFoundError, LASIFWarning
+from lasif.exceptions import LASIFNotFoundError, LASIFWarning
 from obspy.geodetics import FlinnEngdahl
 import pyasdf
 

--- a/lasif/components/project.py
+++ b/lasif/components/project.py
@@ -22,7 +22,7 @@ import warnings
 import toml
 
 import lasif.domain
-from lasif import LASIFError, LASIFNotFoundError, LASIFWarning
+from lasif.exceptions import LASIFError, LASIFNotFoundError, LASIFWarning
 from .adjoint_sources import AdjointSourcesComponent
 from .communicator import Communicator
 from .component import Component

--- a/lasif/components/query.py
+++ b/lasif/components/query.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import collections
 import warnings
 
-from lasif import LASIFError, LASIFNotFoundError, LASIFWarning
+from lasif.exceptions import LASIFError, LASIFNotFoundError, LASIFWarning
 import pyasdf
 
 from .component import Component

--- a/lasif/components/visualizations.py
+++ b/lasif/components/visualizations.py
@@ -9,7 +9,7 @@ import os
 import warnings
 import cartopy as cp
 
-from lasif import LASIFError, LASIFNotFoundError, LASIFWarning
+from lasif.exceptions import LASIFError, LASIFNotFoundError, LASIFWarning
 
 from .component import Component
 

--- a/lasif/components/waveforms.py
+++ b/lasif/components/waveforms.py
@@ -8,7 +8,7 @@ import os
 import warnings
 import pyasdf
 
-from lasif import LASIFNotFoundError, LASIFWarning
+from lasif.exceptions import LASIFNotFoundError, LASIFWarning
 from .component import Component
 
 
@@ -212,8 +212,12 @@ class WaveformsComponent(Component):
             simulation_settings[
                 "end_time_in_s"
             ] = self.comm.project.simulation_settings["end_time_in_s"]
-            simulation_settings["minimum_period"] = self.comm.project.simulation_settings["minimum_period_in_s"]
-            simulation_settings["maximum_period"] = self.comm.project.simulation_settings["maximum_period_in_s"]
+            simulation_settings[
+                "minimum_period"
+            ] = self.comm.project.simulation_settings["minimum_period_in_s"]
+            simulation_settings[
+                "maximum_period"
+            ] = self.comm.project.simulation_settings["maximum_period_in_s"]
         return fct(
             st, simulation_settings, event=self.comm.events.get(event_name)
         )

--- a/lasif/components/weights.py
+++ b/lasif/components/weights.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import glob
 import os
 
-from lasif import LASIFNotFoundError, LASIFError
+from lasif.exceptions import LASIFNotFoundError, LASIFError
 from .component import Component
 
 
@@ -163,9 +163,10 @@ class WeightsComponent(Component):
 
         distance = np.zeros_like(locations[1, :])
 
-        distance = 1.0 / (1.0 + locations2degrees(lat_1, lon_1,
-                                                  locations[0, :],
-                                                  locations[1, :]))
+        distance = 1.0 / (
+            1.0
+            + locations2degrees(lat_1, lon_1, locations[0, :], locations[1, :])
+        )
         factor = np.sum(distance) - 1.0
         weight = 1.0 / factor
 

--- a/lasif/components/windows.py
+++ b/lasif/components/windows.py
@@ -9,7 +9,7 @@ from .component import Component
 
 from ..window_manager_sql import WindowGroupManager
 from lasif.utils import process_two_files_without_parallel_output
-from lasif import LASIFNotFoundError
+from lasif.exceptions import LASIFNotFoundError
 
 
 class WindowsComponent(Component):
@@ -347,8 +347,12 @@ class WindowsComponent(Component):
         )
         delta = self.comm.project.simulation_settings["time_step_in_s"]
         npts = self.comm.project.simulation_settings["number_of_time_steps"]
-        freqmax = 1.0 / self.comm.project.simulation_settings["minimum_period_in_s"]
-        freqmin = 1.0 / self.comm.project.simulation_settings["maximum_period_in_s"]
+        freqmax = (
+            1.0 / self.comm.project.simulation_settings["minimum_period_in_s"]
+        )
+        freqmin = (
+            1.0 / self.comm.project.simulation_settings["maximum_period_in_s"]
+        )
         stf_trace = stf_fct(
             npts=npts, delta=delta, freqmin=freqmin, freqmax=freqmax
         )

--- a/lasif/domain.py
+++ b/lasif/domain.py
@@ -20,7 +20,7 @@ import numpy as np
 import h5py
 from scipy.spatial import cKDTree
 
-from lasif import LASIFNotFoundError, LASIFError
+from lasif.exceptions import LASIFNotFoundError, LASIFError
 from lasif.rotations import lat_lon_radius_to_xyz, xyz_to_lat_lon_radius
 
 

--- a/lasif/exceptions.py
+++ b/lasif/exceptions.py
@@ -1,0 +1,39 @@
+
+class LASIFError(Exception):
+    """
+    Base exception class for LASIF.
+    """
+
+    pass
+
+
+class LASIFNotFoundError(LASIFError):
+    """
+    Raised whenever something is not found inside the project.
+    """
+
+    pass
+
+
+class LASIFAdjointSourceCalculationError(LASIFError):
+    """
+    Raised when something goes wrong when calculating an adjoint source.
+    """
+
+    pass
+
+
+class LASIFWarning(UserWarning):
+    """
+    Base warning class for LASIF.
+    """
+
+    pass
+
+
+class LASIFCommandLineException(LASIFError):
+    """
+    Command line exception.
+    """
+    
+    pass

--- a/lasif/function_templates/preprocessing_function_asdf.py
+++ b/lasif/function_templates/preprocessing_function_asdf.py
@@ -10,7 +10,7 @@ Project specific function processing observed data.
     (http://www.gnu.org/copyleft/gpl.html)
 """
 import numpy as np
-from lasif import LASIFError
+from lasif.exceptions import LASIFError
 from scipy import signal
 from pyasdf import ASDFDataSet
 

--- a/lasif/function_templates/process_data.py
+++ b/lasif/function_templates/process_data.py
@@ -11,7 +11,7 @@ Project specific function processing observed data.
 """
 import numpy as np
 from scipy import signal
-from lasif import LASIFError
+from lasif.exceptions import LASIFError
 
 
 def processing_function(st, inv, simulation_settings, event):  # NOQA

--- a/lasif/salvus_utils.py
+++ b/lasif/salvus_utils.py
@@ -1,7 +1,7 @@
 from lasif.utils import place_receivers, prepare_source
 from typing import Union, List, Dict
 import os
-from lasif import LASIFError
+from lasif.exceptions import LASIFError
 import toml
 from pathlib import Path
 

--- a/lasif/scripts/lasif_cli.py
+++ b/lasif/scripts/lasif_cli.py
@@ -43,7 +43,7 @@ should scale fairly well and makes it trivial to add new methods.
 import os
 import lasif
 from lasif import api
-from lasif.api import LASIFCommandLineException
+from lasif.exceptions import LASIFCommandLineException
 import argparse
 import colorama
 import difflib

--- a/lasif/tools/adjoint/adjoint_source.py
+++ b/lasif/tools/adjoint/adjoint_source.py
@@ -11,7 +11,7 @@ import obspy.signal.filter
 from lasif.tools.adjoint.utils import window_trace, generic_adjoint_source_plot
 
 
-from lasif import LASIFError, LASIFWarning
+from lasif.exceptions import LASIFError, LASIFWarning
 
 
 class AdjointSource(object):

--- a/lasif/tools/adjoint/adjoint_source_types/tf_phase_misfit.py
+++ b/lasif/tools/adjoint/adjoint_source_types/tf_phase_misfit.py
@@ -16,7 +16,7 @@ import obspy
 from obspy.signal.interpolation import lanczos_interpolation
 from lasif.tools.adjoint import utils
 from lasif.adjoint_sources import time_frequency
-from lasif import LASIFAdjointSourceCalculationError
+from lasif.exceptions import LASIFAdjointSourceCalculationError
 
 eps = np.spacing(1)
 VERBOSE_NAME = "Time Frequency Phase Misfit"

--- a/lasif/tools/data_synthetics_iterator.py
+++ b/lasif/tools/data_synthetics_iterator.py
@@ -10,7 +10,7 @@ Two way data synthetics iterator.
     GNU General Public License, Version 3
     (http://www.gnu.org/copyleft/gpl.html)
 """
-from lasif import LASIFNotFoundError
+from lasif.exceptions import LASIFNotFoundError
 
 
 class DataSyntheticIterator(object):

--- a/lasif/tools/query_gcmt_catalog.py
+++ b/lasif/tools/query_gcmt_catalog.py
@@ -20,7 +20,7 @@ import datetime
 import shutil
 from scipy.spatial import cKDTree
 
-from lasif import LASIFNotFoundError, LASIFError
+from lasif.exceptions import LASIFNotFoundError, LASIFError
 
 EARTH_RADIUS = 6371.00
 

--- a/lasif/utils.py
+++ b/lasif/utils.py
@@ -16,7 +16,7 @@ import os
 import numpy as np
 from tqdm import tqdm
 
-from lasif import LASIFError, LASIFNotFoundError
+from lasif.exceptions import LASIFError, LASIFNotFoundError
 
 
 def is_mpi_env():

--- a/lasif/visualization.py
+++ b/lasif/visualization.py
@@ -17,7 +17,7 @@ import cartopy as cp
 import numpy as np
 from obspy.imaging.beachball import beach
 from obspy.signal.tf_misfit import plot_tfr
-from lasif import LASIFError
+from lasif.exceptions import LASIFError
 
 
 def project_points(projection, lon, lat):

--- a/lasif/window_manager_sql.py
+++ b/lasif/window_manager_sql.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from obspy import UTCDateTime
 
 # Register adapter and converter for obspy utc datetime objects
-from lasif import LASIFNotFoundError
+from lasif.exceptions import LASIFNotFoundError
 
 
 def obspy_adapter(utcdt):


### PR DESCRIPTION
In this pull request, I addressed the need for manually having to import the `api` component when required. I felt it was more natural to have this automatically import as soon as you import Lasif itself. One is now able to use the api in the following way:
```
import lasif
lasif.api.<some_api_function>
```

Unfortunately, this clashed with the defined classes (exceptions and errors) in Lasif's `__init__.py` file. To fix this, I moved all classes from this file (and one from `lasif/api.py`) to a new file `exceptions.py`. One required change in the imports throughout the project was the direct import of the exceptions from this file (in the manner of `from lasif.exceptions import LASIFError`), as opposed to imports such as `from lasif import LASIFError`.

To maintain backwards compatability, the exceptions are still directly accessible through the lasif module, e.g.: 
```
import lasif
lasif.LASIFError
```
This is achieved by importing the exceptions in the `__init__.py` file: https://github.com/dirkphilip/LASIF_2.0/blob/2b0856117d8a625b3a00351efb4c04869b83f7a6/lasif/__init__.py#L4-L10