### PR TITLE
Dp/validation misfit function

### DIFF
--- a/lasif/api.py
+++ b/lasif/api.py
@@ -840,6 +840,38 @@ def compute_station_weights(
         weight_set_name=weight_set, weight_set=w_set, events_dict=events_dict,
     )
 
+def calculate_validate_data_misfit(lasif_root, iteration: str,
+                                   events: Union[str, List[str]] = None):
+    """
+    :param lasif_root: path to lasif root directory
+    :type lasif_root: Union[str, pathlib.Path, object]
+    :param iteration: name of iteration
+    :type iteration: str
+    :param events: An event or a list of events. To get all of them pass
+    None, defaults to None
+    :type events: Union[str, List[str]], optional
+    return: misfit
+    """
+    comm = find_project_comm(lasif_root)
+
+    if not comm.iterations.has_iteration(iteration):
+        raise LASIFNotFoundError("Iteration {} not known to LASIF".
+                                 format(iteration))
+        return
+
+    if events is None:
+        events = comm.events.list(iteration=iteration)
+    if isinstance(events, str):
+        events = [events]
+
+    misfit = 0.0
+    for event in events:
+        print(f"Computing L2 validation misfit for event {event}.")
+        misfit += comm.adj_sources.\
+            calculate_validation_misfits(event, iteration)
+
+    return misfit
+
 
 def set_up_iteration(
     lasif_root,
@@ -866,7 +898,6 @@ def set_up_iteration(
     """
 
     comm = find_project_comm(lasif_root)
-
     if events is None:
         events = comm.events.list()
     if isinstance(events, str):

--- a/lasif/scripts/lasif_cli.py
+++ b/lasif/scripts/lasif_cli.py
@@ -770,10 +770,15 @@ def lasif_set_up_iteration(parser, args):
     )
 
     args = parser.parse_args(args)
+    if len(args.events) == 0:
+        events = None
+    else:
+        events = args.events
+
     api.set_up_iteration(
         lasif_root=".",
         iteration=args.iteration_name,
-        events=args.events,
+        events=events,
         remove_dirs=args.remove_dirs,
     )
 

--- a/lasif/utils.py
+++ b/lasif/utils.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 import pathlib
 from typing import Union
 import pyasdf
+import sys
 import math
 
 from lasif.exceptions import LASIFError, LASIFNotFoundError
@@ -143,6 +144,24 @@ def channel2station(value: str):
     'BW.FURT'
     """
     return ".".join(value.split(".")[:2])
+
+
+def progress(count, total, status=""):
+    """
+    Simple progress bar.
+
+    :param count: current count
+    :param total: total of job
+    :param status: reported status
+    """
+    bar_len = 60
+    filled_len = int(round(bar_len * count / float(total)))
+
+    percents = round(100.0 * count / float(total), 1)
+    bar = '=' * filled_len + '-' * (bar_len - filled_len)
+
+    sys.stdout.write('[%s] %s%s ...%s\r' % (bar, percents, '%', status))
+    sys.stdout.flush()
 
 
 def select_component_from_stream(st: obspy.core.Stream, component: str):


### PR DESCRIPTION
Added a function that computes the L2 full trace misfit function for a specific set of events or an iteration.

In contrast to regular L2, all amplitudes are first scaled to a range of [-1.1] to get rid of source or geometric spreading 
effects. 

In addition smaller amplitude waves are unweighted, such that this misfit also becomes sensitive to P -waves for example.
In addition the misfit is scaled by the noise level, so stations with "better looking" seismograms have somewhat more impact
on the measurement.